### PR TITLE
[meta-calaos/curl]add with-ca-bundle compil option for curl

### DIFF
--- a/recipes-support/curl/curl_7.32.0.bb
+++ b/recipes-support/curl/curl_7.32.0.bb
@@ -1,0 +1,2 @@
+
+EXTRA_OECONF += "--with-ca-bundle=${sysconfdir}/ssl/certs/ca-certificates.crt"


### PR DESCRIPTION
used for calaos-mail with smtp.gmail.com

tested on raspberrypi and gmail smtp
