### PR TITLE
Enable connman-autoconnect on all interfaces

### DIFF
--- a/recipes-connectivity/connman/connman-autoconnect/connman-autoconnect
+++ b/recipes-connectivity/connman/connman-autoconnect/connman-autoconnect
@@ -4,20 +4,26 @@
 interface=net.connman.Manager
 member=ServicesChanged
 
+# Enable connman agent to connect to protected Wifi
+connmanctl << EOF
+agent on
+EOF
+
 /usr/bin/dbus-monitor --system --profile "interface='$interface',member='$member'" |
 while read -r line; do
 
         echo "Connman services changed"
 
         (
-        cd /sys/class/net
-        for dev in * ; do
+        for con in $(ls /var/lib/connman|grep -v settings) ; do
+                dev=$(echo $con|cut -d '_' -f 1)
                 if [ "$dev" = "lo" ] ; then continue; fi
                 if [ "$dev" = "sit0" ] ; then continue; fi
-                mac=$(sed 's/://g' < /sys/class/net/$dev/address)
-                echo "Found interface: $dev with addr: $mac, Force connect."
-                /usr/bin/dbus-send --system --type=method_call --print-reply --dest=net.connman /net/connman/service/ethernet_${mac}_cable net.connman.Service.Connect
+                mac=$(echo $con|cut -d '_' -f 2)
+                echo "Found connection medium: $dev with addr: $mac, Force connect."
+                /usr/bin/dbus-send --system --type=method_call --print-reply --dest=net.connman /net/connman/service/$con net.connman.Service.Connect
         done
         );
 
 done
+


### PR DESCRIPTION
Current version only allow ethernet reconnection (tested on RPI3, eth0 and wlan0 available):
`Nov 13 20:58:20 raspberrypi3 connman-autoconnect[250]: Found interface: eth0 with addr: b827eb502d34, Force connect.
Nov 13 20:58:20 raspberrypi3 connman-autoconnect[250]: Error net.connman.Error.AlreadyConnected: Already connected
Nov 13 20:58:20 raspberrypi3 connman-autoconnect[250]: Found interface: wlan0 with addr: b827eb057861, Force connect.
Nov 13 20:58:20 raspberrypi3 connman-autoconnect[250]: Error org.freedesktop.DBus.Error.UnknownObject: Method "Connect" with signature "" on interface "net.connman.Service" doesn't exist
`
PR add support to try to reconnect any interface that has already been connected once, by using connman connection settings files (/var/lib/connman/...), instead of interfaces in /sys/class/net and hardcoded dbus service.
